### PR TITLE
Fix #4: Localize meal planner view mode picker (Day/Week/Month)

### DIFF
--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -580,6 +580,23 @@
         }
       }
     },
+    "Day" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Day"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jour"
+          }
+        }
+      }
+    },
     "Delete" : {
       "localizations" : {
         "en" : {
@@ -1333,6 +1350,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "mealie.domaine.fr"
+          }
+        }
+      }
+    },
+    "Month" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Month"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mois"
           }
         }
       }
@@ -2724,6 +2758,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Voir les rapports serveur"
+          }
+        }
+      }
+    },
+    "Week" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Week"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Semaine"
           }
         }
       }

--- a/MealiePocket/Features/MealPlanner/MealPlannerView.swift
+++ b/MealiePocket/Features/MealPlanner/MealPlannerView.swift
@@ -43,7 +43,7 @@ struct MealPlannerView: View {
                     set: { viewModel.viewMode = $0 }
                 )) {
                     ForEach(MealPlannerViewModel.ViewMode.allCases) { mode in
-                        Text(mode.rawValue).tag(mode)
+                        Text(LocalizedStringKey(mode.rawValue)).tag(mode)
                     }
                 }
                 .pickerStyle(.segmented)

--- a/MealiePocket/Features/MealPlanner/MealPlannerViewModel.swift
+++ b/MealiePocket/Features/MealPlanner/MealPlannerViewModel.swift
@@ -4,9 +4,9 @@ import SwiftUI
 @Observable
 class MealPlannerViewModel {
     enum ViewMode: String, CaseIterable, Identifiable {
-        case day = "Jour"
-        case week = "Semaine"
-        case month = "Mois"
+        case day = "Day"
+        case week = "Week"
+        case month = "Month"
         var id: String { self.rawValue }
     }
     


### PR DESCRIPTION
Fixes #4

Changed `ViewMode` raw values to “Day/Week/Month” and render with `LocalizedStringKey`.  
Added those keys to `Localizable.xcstrings` with English/French translations.

This ensures the planner selector is localized instead of always showing French.