### PR TITLE
Feat/reschedule meal entries

### DIFF
--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -905,7 +905,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Erreur lors du reschedulage du repas"
+            "value" : "Erreur lors de la reprogrammation du repas"
           }
         }
       }

--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -893,6 +893,23 @@
         }
       }
     },
+    "error.reschedulingMeal" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error rescheduling meal"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erreur lors du reschedulage du repas"
+          }
+        }
+      }
+    },
     "Failed to encode request body." : {
       "comment" : "API Error",
       "localizations" : {
@@ -1423,6 +1440,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "mealie.domaine.fr"
+          }
+        }
+      }
+    },
+    "Move" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Move"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Déplacer"
           }
         }
       }
@@ -2175,6 +2208,38 @@
         }
       }
     },
+    "Reschedule" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reschedule"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reprogrammer"
+          }
+        }
+      }
+    },
+    "Reschedule Meal" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reschedule Meal"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reprogrammer le repas"
+          }
+        }
+      }
+    },
     "Save" : {
       "localizations" : {
         "en" : {
@@ -2251,6 +2316,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Résultats de la recherche"
+          }
+        }
+      }
+    },
+    "Select Date" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Select Date"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sélectionner la date"
           }
         }
       }

--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -2235,7 +2235,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Reprogrammer le repas"
+            "value" : "Déplacer le repas"
           }
         }
       }

--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -630,6 +630,23 @@
         }
       }
     },
+    "Dessert" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dessert"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dessert"
+          }
+        }
+      }
+    },
     "Dinner" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -659,6 +676,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Désactiver les commentaires"
+          }
+        }
+      }
+    },
+    "Drink" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Drink"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Boisson"
           }
         }
       }
@@ -2770,6 +2804,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Accompagnement"
+          }
+        }
+      }
+    },
+    "Snack" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Snack"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "En-cas"
           }
         }
       }

--- a/MealiePocket/Core/Networking/MealieAPIClient.swift
+++ b/MealiePocket/Core/Networking/MealieAPIClient.swift
@@ -727,4 +727,12 @@ class MealieAPIClient {
         request.httpMethod = "POST"
         return try await performLongTaskRequest(for: request)
     }
+
+    func rescheduleMealPlanEntry(entryID: Int, toDate: Date, recipeId: UUID, entryType: String) async throws {
+        // Delete the existing entry
+        try await deleteMealPlanEntry(entryID: entryID)
+        
+        // Create a new entry with the new date and meal type
+        try await addMealPlanEntry(date: toDate, recipeId: recipeId, entryType: entryType)
+    }
 }

--- a/MealiePocket/Core/Networking/MealieAPIClient.swift
+++ b/MealiePocket/Core/Networking/MealieAPIClient.swift
@@ -729,10 +729,11 @@ class MealieAPIClient {
     }
 
     func rescheduleMealPlanEntry(entryID: Int, toDate: Date, recipeId: UUID, entryType: String) async throws {
-        // Delete the existing entry
-        try await deleteMealPlanEntry(entryID: entryID)
-        
-        // Create a new entry with the new date and meal type
+        do {
+            try await deleteMealPlanEntry(entryID: entryID)
+        } catch {
+            throw error
+        }
         try await addMealPlanEntry(date: toDate, recipeId: recipeId, entryType: entryType)
     }
 }

--- a/MealiePocket/Core/Networking/MealieAPIClient.swift
+++ b/MealiePocket/Core/Networking/MealieAPIClient.swift
@@ -729,11 +729,7 @@ class MealieAPIClient {
     }
 
     func rescheduleMealPlanEntry(entryID: Int, toDate: Date, recipeId: UUID, entryType: String) async throws {
-        do {
-            try await deleteMealPlanEntry(entryID: entryID)
-        } catch {
-            throw error
-        }
         try await addMealPlanEntry(date: toDate, recipeId: recipeId, entryType: entryType)
+        try await deleteMealPlanEntry(entryID: entryID)
     }
 }

--- a/MealiePocket/Features/MealPlanner/MealPlannerView.swift
+++ b/MealiePocket/Features/MealPlanner/MealPlannerView.swift
@@ -22,7 +22,7 @@ struct MealPlannerView: View {
     
     @State private var showingMealTypeSelection = false
     @State private var selectedMealType = "Dinner"
-    let mealTypes = ["Breakfast", "Lunch", "Dinner", "Side"]
+    let mealTypes = ["Breakfast", "Lunch", "Dinner", "Side", "Drink", "Dessert", "Snack"]
     
     @Environment(\.locale) private var locale
     @Environment(\.dismiss) var dismiss

--- a/MealiePocket/Features/MealPlanner/MealPlannerView.swift
+++ b/MealiePocket/Features/MealPlanner/MealPlannerView.swift
@@ -645,6 +645,9 @@ struct MealPlannerView: View {
         case "lunch": return "Lunch"
         case "dinner": return "Dinner"
         case "side": return "Side"
+        case "drink": return "Drink"
+        case "dessert": return "Dessert"
+        case "snack": return "Snack"
         default: return nil
         }
     }

--- a/MealiePocket/Features/MealPlanner/MealPlannerView.swift
+++ b/MealiePocket/Features/MealPlanner/MealPlannerView.swift
@@ -32,10 +32,6 @@ struct MealPlannerView: View {
     @Namespace var unionNamespace
     
     var body: some View {
-        mainContent
-    }
-    
-    private var mainContent: some View {
         VStack {
             header
             contentView
@@ -221,6 +217,7 @@ struct MealPlannerView: View {
                     selectedMealType: $selectedReschedueMealType,
                     mealTypes: mealTypes,
                     onConfirm: {
+                        viewModel.showingRescheduleSheet = false
                         if let entryID = viewModel.selectedRescheduleEntryID {
                             Task {
                                 await viewModel.rescheduleMealEntry(
@@ -662,7 +659,12 @@ struct RescheduleSheet: View {
     
     var body: some View {
         NavigationView {
-            VStack(spacing: 16) {
+            VStack(spacing: 4) {
+                Text(LocalizedStringKey("Reschedule Meal"))
+                    .font(.title3)
+                    .fontWeight(.semibold)
+                    .padding(.top, 0)
+                
                 VStack(alignment: .leading, spacing: 8) {
                     DatePicker(
                         "Date",
@@ -671,43 +673,31 @@ struct RescheduleSheet: View {
                     )
                     .datePickerStyle(.graphical)
                 }
-                .padding()
+                .padding(.horizontal)
                 
                 VStack(alignment: .leading, spacing: 8) {
                     Text("Meal Type")
-                        .font(.headline)
+                        .font(.title3)
                         .fontWeight(.semibold)
                         .foregroundColor(.secondary)
+                        .frame(maxWidth: .infinity, alignment: .center)
+                        .padding(.horizontal)
+                        .padding(.top, 12)
                     
-                    let columns = [GridItem(.flexible()), GridItem(.flexible())]
-                    LazyVGrid(columns: columns, spacing: 8) {
+                    Picker("Meal Type", selection: $selectedMealType) {
                         ForEach(mealTypes, id: \.self) { type in
-                            if selectedMealType == type {
-                                Button {
-                                    selectedMealType = type
-                                } label: {
-                                    Text(LocalizedStringKey(type))
-                                        .frame(maxWidth: .infinity)
-                                }
-                                .buttonStyle(.borderedProminent)
-                            } else {
-                                Button {
-                                    selectedMealType = type
-                                } label: {
-                                    Text(LocalizedStringKey(type))
-                                        .frame(maxWidth: .infinity)
-                                }
-                                .buttonStyle(.bordered)
-                            }
+                            Text(LocalizedStringKey(type))
+                                .font(.title3)
+                                .tag(type)
                         }
                     }
+                    .pickerStyle(.wheel)
                 }
-                .padding()
-                
-                Spacer()
+                .padding(.horizontal)
             }
-            .navigationTitle("Reschedule Meal")
-            .navigationBarTitleDisplayMode(.inline)
+            .padding(.horizontal)
+            .padding(.top, 4)
+            .padding(.bottom)
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
                     Button("Cancel", action: onCancel)

--- a/MealiePocket/Features/MealPlanner/MealPlannerViewModel.swift
+++ b/MealiePocket/Features/MealPlanner/MealPlannerViewModel.swift
@@ -209,7 +209,7 @@ class MealPlannerViewModel {
         }
         
         guard let client = self.apiClient else {
-            errorMessage = String(localized: "error.apiClientUnavailable")
+            errorMessage = "error.apiClientUnavailable"
             isLoading = false
             isLoadingPast = false
             isLoadingFuture = false
@@ -248,7 +248,7 @@ class MealPlannerViewModel {
             }
         } catch {
             await MainActor.run {
-                errorMessage = String(localized: "error.loadingPlan") + ": " + error.localizedDescription
+                errorMessage = "error.loadingPlan"
                 self.isLoading = false
                 self.isLoadingPast = false
                 self.isLoadingFuture = false
@@ -344,7 +344,7 @@ class MealPlannerViewModel {
     
     func addSelectedRecipeToPlan(recipe: RecipeSummary, mealType: String, apiClient: MealieAPIClient?) async {
         guard let date = dateForAddingRecipe, let apiClient = apiClient else {
-            errorMessage = String(localized: "error.missingDateOrClient")
+            errorMessage = "error.missingDateOrClient"
             return
         }
         
@@ -360,7 +360,7 @@ class MealPlannerViewModel {
             }
         } catch {
             await MainActor.run {
-                errorMessage = String(localized: "error.addingMeal") + ": " + error.localizedDescription
+                errorMessage = "error.addingMeal"
                 isLoading = false
             }
         }
@@ -368,7 +368,7 @@ class MealPlannerViewModel {
 
     func addRandomMeal(date: Date, mealType: String) async {
         guard let date = dateForAddingRecipe, let apiClient = apiClient else {
-            errorMessage = String(localized: "error.apiClientUnavailable")
+            errorMessage = "error.apiClientUnavailable"
             return
         }
         
@@ -384,7 +384,7 @@ class MealPlannerViewModel {
             }
         } catch {
             await MainActor.run {
-                errorMessage = String(localized: "error.randomMeal") + ": " + error.localizedDescription
+                errorMessage = "error.randomMeal"
                 isLoading = false
             }
         }
@@ -392,7 +392,7 @@ class MealPlannerViewModel {
 
     func deleteMealEntry(entryID: Int) async {
         guard let client = self.apiClient else {
-            errorMessage = String(localized: "error.apiClientUnavailable")
+            errorMessage = "error.apiClientUnavailable"
             return
         }
         
@@ -404,7 +404,7 @@ class MealPlannerViewModel {
             await loadMealPlan(apiClient: client)
         } catch {
             await MainActor.run {
-                errorMessage = String(localized: "error.deletingMeal") + ": " + error.localizedDescription
+                errorMessage = "error.deletingMeal"
                 isLoading = false
             }
         }
@@ -427,7 +427,7 @@ class MealPlannerViewModel {
     @MainActor
     func rescheduleMealEntry(entryID: Int, toDate: Date, recipeId: UUID, mealType: String) async {
         guard let client = self.apiClient else {
-            errorMessage = String(localized: "error.apiClientUnavailable")
+            errorMessage = "error.apiClientUnavailable"
             return
         }
         
@@ -440,7 +440,7 @@ class MealPlannerViewModel {
             showingRescheduleSheet = false
             isLoading = false
         } catch {
-            errorMessage = String(localized: "error.reschedulingMeal") + ": " + error.localizedDescription
+            errorMessage = "error.reschedulingMeal"
             isLoading = false
         }
     }
@@ -448,7 +448,7 @@ class MealPlannerViewModel {
     @MainActor
     private func prepareImport(startDate: Date, endDate: Date, apiClient: MealieAPIClient?) {
         guard apiClient != nil else {
-            errorMessage = String(localized: "error.apiClientUnavailable")
+            errorMessage = "error.apiClientUnavailable"
             return
         }
         
@@ -499,7 +499,7 @@ class MealPlannerViewModel {
     @MainActor
     func loadShoppingLists() async {
         guard let apiClient else {
-            importErrorMessage = String(localized: "error.apiClientUnavailable")
+            importErrorMessage = "error.apiClientUnavailable"
             return
         }
         
@@ -519,7 +519,7 @@ class MealPlannerViewModel {
     @MainActor
     func importMealsToShoppingList(list: ShoppingListSummary) async {
         guard let apiClient else {
-            importErrorMessage = String(localized: "error.apiClientUnavailable")
+            importErrorMessage = "error.apiClientUnavailable"
             return
         }
         


### PR DESCRIPTION
Resolves #7

## Summary
Planner follow-ups: small improvements across UX, chores, optimizations, and translations.

## What changed
- **Feature:** Added meal rescheduling from planner entries (context menu flow).
- **Chores:** Applied review-driven cleanup/refinements across planner and related API handling.
- **Optimizations:** Simplified planner error/localization handling — removed `String(localized: ...)` usage in favor of key-based approach.
- **Translations:** Added en/fr entries for new meal types (`Drink`, `Dessert`, `Snack`) and updated planner-related keys.