### PR TITLE
fix: make RecipeIngredient.note optional to handle null API values (#23)

### DIFF
--- a/MealiePocket/Core/Models/Recipe.swift
+++ b/MealiePocket/Core/Models/Recipe.swift
@@ -108,13 +108,13 @@ struct RecipeIngredient: Codable, Identifiable, Hashable {
     var referenceId: String?
     var display: String
     var title: String?
-    var note: String
+    var note: String?
     var quantity: Double?
     var unit: IngredientUnitStub?
     var food: IngredientFoodStub?
     var originalText: String?
     
-    init(id: UUID = UUID(), referenceId: String? = nil, display: String = "", title: String? = nil, note: String = "", quantity: Double? = 0, unit: IngredientUnitStub? = nil, food: IngredientFoodStub? = nil, originalText: String? = nil) {
+    init(id: UUID = UUID(), referenceId: String? = nil, display: String = "", title: String? = nil, note: String? = nil, quantity: Double? = 0, unit: IngredientUnitStub? = nil, food: IngredientFoodStub? = nil, originalText: String? = nil) {
         self.id = id
         self.referenceId = referenceId
         self.display = display

--- a/MealiePocket/Features/Recipes/Edit/EditRecipeView.swift
+++ b/MealiePocket/Features/Recipes/Edit/EditRecipeView.swift
@@ -72,7 +72,10 @@ struct EditRecipeView: View {
                                 .tint(.primary)
                             }
                             
-                            TextEditor(text: $ingredient.note)
+                            TextEditor(text: Binding(
+                                get: { ingredient.note ?? "" },
+                                set: { ingredient.note = $0 }
+                            ))
                                 .frame(minHeight: 30)
                                 .font(.subheadline)
                                 .foregroundColor(.secondary)


### PR DESCRIPTION
Changes:
- Changed RecipeIngredient.note from String to String? in Recipe model
- Updated initializer default from empty string to nil
- Updated TextEditor binding in EditRecipeView to handle optional String

This fix was more involved than initially thought. Making note optional required updating the EditRecipeView where TextEditor binding expects non-optional String. Implemented a custom binding that converts between optional and non-optional types.

Now gracefully handles recipes with ingredients that have null notes from the API, preventing decoding errors and making recipes with such ingredients accessible.

Closes #23 