### PR TITLE
feat: add recipe ingredient scaling support

### DIFF
--- a/MealiePocket/Core/Networking/MealieAPIClient.swift
+++ b/MealiePocket/Core/Networking/MealieAPIClient.swift
@@ -654,7 +654,7 @@ class MealieAPIClient {
         let _: NoReply = try await performRequest(for: request)
     }
     
-    func addRecipesToShoppingListBulk(listId: UUID, recipeIds: [UUID]) async throws -> ShoppingListDetail {
+    func addRecipesToShoppingListBulk(listId: UUID, recipeIds: [UUID], scale: Double = 1.0) async throws -> ShoppingListDetail {
         guard !recipeIds.isEmpty else {
             
             throw APIError.invalidURL
@@ -665,7 +665,7 @@ class MealieAPIClient {
         request.httpMethod = "POST"
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
         
-        let payload = recipeIds.map { ShoppingListAddRecipeParamsBulkPayload(recipeId: $0.uuidString.lowercased()) }
+        let payload = recipeIds.map { ShoppingListAddRecipeParamsBulkPayload(recipeId: $0.uuidString.lowercased(), scale: scale) }
         
         do {
             request.httpBody = try JSONEncoder().encode(payload)

--- a/MealiePocket/Features/Recipes/Details/RecipeDetailView.swift
+++ b/MealiePocket/Features/Recipes/Details/RecipeDetailView.swift
@@ -117,7 +117,7 @@ struct RecipeDetailView: View {
                     }
                     .lineLimit(1)
                     
-                    let servingsValue: Double? = detail.recipeServings
+                    let servingsValue: Double? = viewModel.currentServings
                     let isSingular: Bool = servingsValue == 1.0
 
                     let servingsLabel: LocalizedStringKey = isSingular ? "Portion" : "Portions"
@@ -195,13 +195,75 @@ struct RecipeDetailView: View {
     private func ingredientsSection(ingredients: [RecipeIngredient]) -> some View {
         VStack(alignment: .leading, spacing: 12) {
             Text("Ingredients").font(.title2.weight(.semibold)).padding(.horizontal)
+            
+            if let servings = viewModel.originalServings, servings > 0 {
+                servingsAdjuster()
+                    .padding(.horizontal)
+            }
+            
             LazyVStack(alignment: .leading, spacing: 10) {
                 ForEach(ingredients) { ingredient in
-                    IngredientRow(text: ingredient.display)
+                    IngredientRow(text: viewModel.scaledDisplayText(for: ingredient))
                 }
             }
             .padding(.horizontal)
         }
+    }
+    
+    private func servingsAdjuster() -> some View {
+        HStack(spacing: 16) {
+            Button {
+                hapticImpact(style: .light)
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    viewModel.decrementServings()
+                }
+            } label: {
+                Image(systemName: "minus.circle.fill")
+                    .font(.title2)
+                    .foregroundColor((viewModel.currentServings ?? 1) <= 1 ? .gray : .accentColor)
+            }
+            .disabled((viewModel.currentServings ?? 1) <= 1)
+            
+            VStack(spacing: 2) {
+                Text(IngredientScaler.formatQuantity(viewModel.currentServings ?? 0))
+                    .font(.title3.weight(.bold))
+                    .monospacedDigit()
+                    .contentTransition(.numericText())
+                Text((viewModel.currentServings ?? 0) == 1 ? "Portion" : "Portions")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            .frame(minWidth: 60)
+            
+            Button {
+                hapticImpact(style: .light)
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    viewModel.incrementServings()
+                }
+            } label: {
+                Image(systemName: "plus.circle.fill")
+                    .font(.title2)
+                    .foregroundColor(.accentColor)
+            }
+            
+            if viewModel.isScaled {
+                Button {
+                    hapticImpact(style: .light)
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        viewModel.resetServings()
+                    }
+                } label: {
+                    Image(systemName: "arrow.counterclockwise.circle.fill")
+                        .font(.title3)
+                        .foregroundColor(.orange)
+                }
+                .transition(.scale.combined(with: .opacity))
+            }
+        }
+        .padding(.vertical, 10)
+        .padding(.horizontal, 20)
+        .background(.thinMaterial)
+        .cornerRadius(12)
     }
     
     private func instructionsSection(instructions: [RecipeInstruction]) -> some View {

--- a/MealiePocket/Features/Recipes/Details/RecipeDetailViewModel.swift
+++ b/MealiePocket/Features/Recipes/Details/RecipeDetailViewModel.swift
@@ -133,6 +133,64 @@ class RecipeDetailViewModel {
         }
     }
     
+    // MARK: - Recipe Scaling
+    
+    var targetServings: Double? = nil
+    
+    var originalServings: Double? {
+        recipeDetail?.recipeServings
+    }
+    
+    var scaleFactor: Double {
+        IngredientScaler.scaleFactor(originalServings: originalServings, targetServings: targetServings)
+    }
+    
+    var isScaled: Bool {
+        guard let target = targetServings, let original = originalServings else { return false }
+        return abs(target - original) > 0.01
+    }
+    
+    var currentServings: Double? {
+        targetServings ?? originalServings
+    }
+    
+    func incrementServings() {
+        guard let current = currentServings else { return }
+        targetServings = current + 1
+    }
+    
+    func decrementServings() {
+        guard let current = currentServings, current > 1 else { return }
+        targetServings = current - 1
+    }
+    
+    func resetServings() {
+        targetServings = nil
+    }
+    
+    func scaledDisplayText(for ingredient: RecipeIngredient) -> String {
+        let scale = scaleFactor
+        guard scale != 1.0, let originalQty = ingredient.quantity, originalQty > 0 else {
+            return ingredient.display
+        }
+        
+        let scaledQty = originalQty * scale
+        let formattedQty = IngredientScaler.formatQuantity(scaledQty)
+        
+        var parts: [String] = [formattedQty]
+        if let unit = ingredient.unit {
+            parts.append(unit.name)
+        }
+        if let food = ingredient.food {
+            parts.append(food.name)
+        }
+        if !ingredient.note.isEmpty {
+            parts.append(ingredient.note)
+        }
+        
+        return parts.joined(separator: " ")
+    }
+    
     @MainActor
     func markForRefresh() {
         needsRefresh = true

--- a/MealiePocket/Utilities/IngredientScaler.swift
+++ b/MealiePocket/Utilities/IngredientScaler.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+/// Reusable utility for scaling recipe ingredients and formatting quantities.
+/// Display formatting lives here; actual shopping-list scaling is handled server-side
+/// via the Mealie API `scale` parameter.
+enum IngredientScaler {
+    
+    // MARK: - Scaling
+    
+    /// Calculates the scale factor from original to target servings.
+    static func scaleFactor(originalServings: Double?, targetServings: Double?) -> Double {
+        guard let original = originalServings, original > 0,
+              let target = targetServings, target > 0 else {
+            return 1.0
+        }
+        return target / original
+    }
+    
+    // MARK: - Display Formatting
+    
+    /// Formats a numeric quantity for display. Whole numbers are shown as integers,
+    /// common fractions are rendered as unicode fraction characters,
+    /// and other values use up to 2 decimal places.
+    private static let quantityFormatter: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.minimumFractionDigits = 0
+        formatter.maximumFractionDigits = 2
+        formatter.numberStyle = .decimal
+        return formatter
+    }()
+    
+    static func formatQuantity(_ value: Double) -> String {
+        if value == floor(value) && value < 100000 {
+            return String(Int(value))
+        }
+        
+        let whole = Int(value)
+        let fractional = value - Double(whole)
+        
+        if let vulgar = vulgarFraction(for: fractional) {
+            return whole > 0 ? "\(whole) \(vulgar)" : vulgar
+        }
+        
+        return quantityFormatter.string(from: NSNumber(value: value)) ?? String(format: "%.2g", value)
+    }
+    
+    /// Maps a fractional value (0..1) to a Unicode fraction character if it is
+    /// within the given tolerance of a known fraction.
+    static func vulgarFraction(for fractional: Double, tolerance: Double = 0.05) -> String? {
+        let fractions: [(threshold: Double, symbol: String)] = [
+            (1.0 / 8.0, "\u{215B}"),
+            (1.0 / 6.0, "\u{2159}"),
+            (1.0 / 5.0, "\u{2155}"),
+            (1.0 / 4.0, "\u{00BC}"),
+            (1.0 / 3.0, "\u{2153}"),
+            (3.0 / 8.0, "\u{215C}"),
+            (2.0 / 5.0, "\u{2156}"),
+            (1.0 / 2.0, "\u{00BD}"),
+            (3.0 / 5.0, "\u{2157}"),
+            (5.0 / 8.0, "\u{215D}"),
+            (2.0 / 3.0, "\u{2154}"),
+            (3.0 / 4.0, "\u{00BE}"),
+            (4.0 / 5.0, "\u{2158}"),
+            (5.0 / 6.0, "\u{215A}"),
+            (7.0 / 8.0, "\u{215E}"),
+        ]
+        
+        for fraction in fractions {
+            if abs(fractional - fraction.threshold) < tolerance {
+                return fraction.symbol
+            }
+        }
+        return nil
+    }
+}


### PR DESCRIPTION
Add UI controls to adjust servings on the recipe detail screen and recalculate ingredient quantities accordingly. Fractional amounts are displayed as unicode fractions (e.g. ½, ⅓, ¾) for readability.

Changes:
- Add servings adjuster (+/- stepper with reset) to ingredients section
- Scale ingredient quantities based on target vs original servings
- Add IngredientScaler utility for scale factor calculation and quantity formatting with unicode fraction support
- Accept scale parameter in addRecipesToShoppingListBulk API method to prepare for future add-to-list with scaling

Closes #14